### PR TITLE
Fix SSL Handshake Failure w/ jGIT

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+/docs/
+/scripts/
+
+/.git*
+/*.bat
+/Dockerfile
+/LICENSE
+/README.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,5 @@ COPY . /sigidoc
 WORKDIR /sigidoc
 
 RUN apk --no-cache add bash
-RUN sed -i 's/SSLv3/&, SSLv2/' /opt/java/openjdk/jre/lib/security/java.security
 
 CMD ["./build.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM eclipse-temurin:8u432-b06-jdk-alpine
+FROM eclipse-temurin:8u442-b06-jdk
 
 COPY . /sigidoc
 WORKDIR /sigidoc
-
-RUN apk --no-cache add bash
 
 CMD ["./build.sh"]


### PR DESCRIPTION
This pull request switches from the Alpine Linux-flavoured base image `eclipse-temurin:8u432-b06-jdk-alpine` to the default Java 8 base image `eclipse-temurin:8u432-b06-jdk`, which seems to correct a problem occuring during the SSL/TLS handshake between the employed jGIT implementation and `github.com`.

The pull request furthermore introduces a `.dockerignore` file to drastically reduce the resulting container image size (~50% smaller), by ignoring, i.e., the `/.git/` and `/docs/` paths.