### PR TITLE
Refine Docker Deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 /scripts/
 
 /.git*
-/*.bat
+/build.*
 /Dockerfile
 /LICENSE
 /README.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM eclipse-temurin:8u442-b06-jdk
+FROM eclipse-temurin:8-jdk-alpine
 
 COPY . /sigidoc
 WORKDIR /sigidoc
 
-CMD ["./build.sh"]
+ENV ANT_OPTS=" \
+  -Dinfo.aduna.platform.appdata.basedir=./webapps/openrdf-sesame/app_dir/ \
+  -Dorg.eclipse.jetty.LEVEL=WARN"
+
+CMD ["sw/ant/bin/ant", "-f", "local.build.xml"]

--- a/docker.sh
+++ b/docker.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-docker build -t sigidoc .
-docker run -it -p 9999:9999 -v ~/Siegel:/sigidoc/webapps/ROOT/content/xml/epidoc -v ~/authority:/sigidoc/webapps/ROOT/content/xml/authority --rm --name sigidoc sigidoc


### PR DESCRIPTION
This pull request refines the SigiDoc Docker deployment by dropping the usage of the `build.sh` wrapper shell script an invoking `ant` directly (via the Docker `EXEC`-format of the `CMD` statement). Furthermore, the Docker base image was changed to `eclipse-temurin:8-jdk-alpine`, which is a rolling release of Java (1.)8, based on Alpine Linux. By not adopting the hardcoded `-Xmx512m` from the `build.sh` script, the environment variable `_JAVA_OPTIONS=-Xmx...` may now be used to, e.g., enforce memory limits.